### PR TITLE
Use "depends" instead of "requires" in fabric mod json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -43,7 +43,7 @@
 			"config": "tweed.mixin.json"
 		}
 	],
-	"requires": {
+	"depends": {
 		"fabricloader": ">=0.4.0"
 	},
 	"suggests": {


### PR DESCRIPTION
As per [reference](https://fabricmc.net/wiki/documentation:fabric_mod_json#dependency_resolution), fixes a warning on startup.