### PR TITLE
Mark MixinClientPlayNetworkHandler client side

### DIFF
--- a/src/main/java/de/siphalor/tweed/mixin/client/MixinClientPlayNetworkHandler.java
+++ b/src/main/java/de/siphalor/tweed/mixin/client/MixinClientPlayNetworkHandler.java
@@ -12,6 +12,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+@Environment(EnvType.CLIENT)
 @Mixin(ClientPlayNetworkHandler.class)
 public class MixinClientPlayNetworkHandler {
 	@Inject(method = "onGameJoin", at = @At("RETURN"), require = 0)

--- a/src/main/resources/tweed.mixin.json
+++ b/src/main/resources/tweed.mixin.json
@@ -4,7 +4,9 @@
 	"compatibilityLevel": "JAVA_8",
 	"mixins": [
 		"MinecraftServerAccessor",
-		"MixinMinecraftServer",
+		"MixinMinecraftServer"
+	],
+	"client": [
 		"client.MixinClientPlayNetworkHandler"
 	],
 	"injectors": {


### PR DESCRIPTION
I think I've done this right, fixes the server side warning
> [main/WARN]: Error loading class: net/minecraft/class_634 (java.lang.ClassNotFoundException: net/minecraft/class_634)
> [main/WARN]: @Mixin target net.minecraft.class_634 was not found tweed.mixin.json:client.MixinClientPlayNetworkHandler
