### PR TITLE
[Experimental] Custom EntryConverters and IntSliderConverter

### DIFF
--- a/src/main/java/de/siphalor/tweed/client/cloth/IntSliderConverter.java
+++ b/src/main/java/de/siphalor/tweed/client/cloth/IntSliderConverter.java
@@ -1,0 +1,24 @@
+package de.siphalor.tweed.client.cloth;
+
+import de.siphalor.tweed.config.entry.ValueConfigEntry;
+import de.siphalor.tweed.tailor.ClothTailor;
+import me.shedaniel.clothconfig2.api.AbstractConfigListEntry;
+import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
+import net.minecraft.text.TranslatableText;
+
+public class IntSliderConverter implements ClothTailor.EntryConverter<Integer>{
+    final int min, max;
+
+    public IntSliderConverter(String[] args) {
+        min = Integer.parseInt(args[0]);
+        max = Integer.parseInt(args[1]);
+    }
+
+    @Override
+    public AbstractConfigListEntry<?> convert(ValueConfigEntry<Integer> entry, ConfigEntryBuilder builder, String s) {
+        return builder.startIntSlider(new TranslatableText(s), entry.getMainConfigValue(), min, max)
+            .setDefaultValue(entry.getDefaultValue())
+            .setSaveConsumer(entry::setMainConfigValue)
+            .build();
+    }
+}

--- a/src/main/java/de/siphalor/tweed/client/cloth/IntSliderConverter.java
+++ b/src/main/java/de/siphalor/tweed/client/cloth/IntSliderConverter.java
@@ -4,7 +4,10 @@ import de.siphalor.tweed.config.entry.ValueConfigEntry;
 import de.siphalor.tweed.tailor.ClothTailor;
 import me.shedaniel.clothconfig2.api.AbstractConfigListEntry;
 import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
+import net.minecraft.text.LiteralText;
 import net.minecraft.text.TranslatableText;
+
+import java.util.Optional;
 
 public class IntSliderConverter implements ClothTailor.EntryConverter<Integer>{
     final int min, max;
@@ -19,6 +22,11 @@ public class IntSliderConverter implements ClothTailor.EntryConverter<Integer>{
         return builder.startIntSlider(new TranslatableText(s), entry.getMainConfigValue(), min, max)
             .setDefaultValue(entry.getDefaultValue())
             .setSaveConsumer(entry::setMainConfigValue)
+            .setErrorSupplier((Integer value) -> {
+                if (value < min || value > max)
+                    return Optional.of(new LiteralText(String.format("value should be between %d and %d", min, max)));
+                return Optional.empty();
+            })
             .build();
     }
 }

--- a/src/main/java/de/siphalor/tweed/config/annotated/AConfigConverter.java
+++ b/src/main/java/de/siphalor/tweed/config/annotated/AConfigConverter.java
@@ -1,0 +1,16 @@
+package de.siphalor.tweed.config.annotated;
+
+import de.siphalor.tweed.tailor.ClothTailor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface AConfigConverter {
+    @SuppressWarnings("rawtypes")
+    Class<? extends ClothTailor.EntryConverter> type();
+    String[] args();
+}

--- a/src/main/java/de/siphalor/tweed/tailor/ClothTailor.java
+++ b/src/main/java/de/siphalor/tweed/tailor/ClothTailor.java
@@ -120,21 +120,23 @@ public class ClothTailor extends Tailor {
 				registry.accept(categoryBuilder.build());
 
 			} else if (entry.getValue() instanceof ValueConfigEntry<?>) {
-				Class<?> clazz = ((ValueConfigEntry<?>) entry.getValue()).getType();
-				EntryConverter<?> entryConverter;
-
-				entryConverter = ENTRY_CONVERTERS.get(clazz);
-				main:
-				while (clazz != Object.class && entryConverter == null) {
-					for (Class<?> anInterface : clazz.getInterfaces()) {
-						entryConverter = ENTRY_CONVERTERS.get(anInterface);
-						if (entryConverter != null) {
-							break main;
-						}
-					}
-
-					clazz = clazz.getSuperclass();
+				ValueConfigEntry<?> valueEntry = ((ValueConfigEntry<?>) entry.getValue());
+				EntryConverter<?> entryConverter = valueEntry.getCustomEntryConverter();
+				if (entryConverter == null) {
+					Class<?> clazz = ((ValueConfigEntry<?>) entry.getValue()).getType();
 					entryConverter = ENTRY_CONVERTERS.get(clazz);
+					main:
+					while (clazz != Object.class && entryConverter == null) {
+						for (Class<?> anInterface : clazz.getInterfaces()) {
+							entryConverter = ENTRY_CONVERTERS.get(anInterface);
+							if (entryConverter != null) {
+								break main;
+							}
+						}
+
+						clazz = clazz.getSuperclass();
+						entryConverter = ENTRY_CONVERTERS.get(clazz);
+					}
 				}
 
 				if (entryConverter != null) {

--- a/src/testmod/java/de/siphalor/tweedtest/Config.java
+++ b/src/testmod/java/de/siphalor/tweedtest/Config.java
@@ -2,6 +2,7 @@ package de.siphalor.tweedtest;
 
 import com.google.common.base.CaseFormat;
 import de.siphalor.tweed.Tweed;
+import de.siphalor.tweed.client.cloth.IntSliderConverter;
 import de.siphalor.tweed.config.ConfigEnvironment;
 import de.siphalor.tweed.config.ConfigScope;
 import de.siphalor.tweed.config.annotated.*;
@@ -21,6 +22,11 @@ public class Config {
 
 	@AConfigEntry(constraints = @AConfigConstraint(value = RangeConstraint.class, param = "100..200"))
 	public static Integer number = 123;
+
+	// TODO: a RangeConstraint can be added, but it won't do anything except throw an Exception when the range is out of bounds
+	@AConfigEntry
+	@AConfigConverter(type = IntSliderConverter.class, args = {"-100", "100"})
+	public static int slider = 0;
 
 	@AConfigEntry(comment = "This is an object")
 	public static A a;


### PR DESCRIPTION
## Description

- add `AConfigConverter` annotation which allows to set a custom `EntryConverter` for each config entry
- add `IntSliderConverter` for use with `AConfigConverter`

An example usage for both is
```
	@AConfigEntry
	@AConfigConverter(type = IntSliderConverter.class, args = {"-100", "100"})
	public static int slider = 0;
```
to create an IntSlider with minimum -100 and maximum 100.
I figured that making `args` a `String[]` would be the most generic.
I'm not sure if there's a good way to ensure `type` is a compatible class - one with a `String[]` constructor.

![Test](https://user-images.githubusercontent.com/8464472/104815382-71658180-5814-11eb-84d6-0c7fce34f3b9.png)

## TODO
- error logging
- figure out what to do with `RangeConstraint`s on sliders

The slider config entry can have a `RangeConstraint`, but adding it won't actually do anything except generate an exception when the value is out of bounds (e.g. when manually set in the config file).

I was expecting that the `RangeConstraint` would automatically clamp values between the min and max, instead you get this funny looking guy:
![Constraints](https://user-images.githubusercontent.com/8464472/104815318-074cdc80-5814-11eb-8901-1edfe087304b.png)

~~Text boxes with a `RangeConstraint` do get red text and a warning on the top and I'm not sure how to add that.~~

## Related Issues

https://github.com/Siphalor/tweed-api/issues/18
